### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project is a simple React and TypeScript dashboard built with Vite and Tailwind CSS.
 
+The interface supports a light and dark theme. Use the sun/moon button in the header to toggle between modes. Your preference is saved in `localStorage`.
+
 ## Prerequisites
 
 - Node.js (version 18 or later)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useMemo } from 'react';
-import { Plus, Menu, LayoutDashboard } from 'lucide-react';
+import React, { useState, useMemo, useEffect } from 'react';
+import { Plus, Menu, LayoutDashboard, Sun, Moon } from 'lucide-react';
 import { PlatformCard } from './components/PlatformCard';
 import { AddPlatformModal } from './components/AddPlatformModal';
 import { FilterSidebar } from './components/FilterSidebar';
@@ -13,6 +13,24 @@ function App() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+      setIsDarkMode(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isDarkMode) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDarkMode]);
 
   const filteredPlatforms = useMemo(() => {
     return platforms.filter(platform => {
@@ -46,7 +64,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
       {/* Desktop Sidebar */}
       <div className="hidden lg:block">
         <FilterSidebar
@@ -79,13 +97,13 @@ function App() {
       {/* Main Content */}
       <div className="flex-1 flex flex-col min-h-screen">
         {/* Header */}
-        <header className="bg-white border-b border-gray-200 shadow-sm">
+        <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 shadow-sm">
           <div className="px-4 sm:px-6 lg:px-8 py-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-4">
                 <button
                   onClick={() => setIsMobileSidebarOpen(true)}
-                  className="lg:hidden p-2 hover:bg-gray-100 rounded-lg transition-colors"
+                  className="lg:hidden p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
                 >
                   <Menu className="w-5 h-5" />
                 </button>
@@ -102,13 +120,26 @@ function App() {
                 </div>
               </div>
               
-              <button
-                onClick={() => setIsAddModalOpen(true)}
-                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium shadow-sm hover:shadow-md"
-              >
-                <Plus className="w-4 h-4" />
-                <span className="hidden sm:inline">Add Platform</span>
-              </button>
+              <div className="flex items-center space-x-4">
+                <button
+                  onClick={() => setIsDarkMode(!isDarkMode)}
+                  className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+                  aria-label="Toggle dark mode"
+                >
+                  {isDarkMode ? (
+                    <Sun className="w-5 h-5" />
+                  ) : (
+                    <Moon className="w-5 h-5" />
+                  )}
+                </button>
+                <button
+                  onClick={() => setIsAddModalOpen(true)}
+                  className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium shadow-sm hover:shadow-md"
+                >
+                  <Plus className="w-4 h-4" />
+                  <span className="hidden sm:inline">Add Platform</span>
+                </button>
+              </div>
             </div>
           </div>
         </header>

--- a/src/components/AddPlatformModal.tsx
+++ b/src/components/AddPlatformModal.tsx
@@ -67,12 +67,12 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-        <div className="flex items-center justify-between p-6 border-b border-gray-100">
-          <h2 className="text-2xl font-bold text-gray-900">Add New Platform</h2>
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Add New Platform</h2>
           <button
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
             aria-label="Close"
           >
             <X className="w-5 h-5" />
@@ -83,28 +83,28 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                 Platform Name *
               </label>
               <input
                 type="text"
                 value={formData.name}
                 onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-                className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 placeholder="e.g., GitHub"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                 URL *
               </label>
               <input
                 type="url"
                 value={formData.url}
                 onChange={(e) => setFormData(prev => ({ ...prev, url: e.target.value }))}
-                className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 placeholder="https://example.com"
                 required
               />
@@ -112,27 +112,27 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
               Description
             </label>
             <textarea
               value={formData.description}
               onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
               rows={3}
-              className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all resize-none"
+              className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all resize-none"
               placeholder="Brief description of the platform..."
             />
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                 Main Category *
               </label>
               <select
                 value={formData.mainCategory}
                 onChange={(e) => handleMainCategoryChange(e.target.value)}
-                className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 required
               >
                 <option value="">Select category</option>
@@ -145,13 +145,13 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                 Sub Category *
               </label>
               <select
                 value={formData.subCategory}
                 onChange={(e) => setFormData(prev => ({ ...prev, subCategory: e.target.value }))}
-                className="w-full px-4 py-3 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 disabled={!formData.mainCategory}
                 required
               >
@@ -166,7 +166,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-3">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
               Icon
             </label>
             <div className="grid grid-cols-8 gap-2">
@@ -182,7 +182,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
                     className={`p-3 rounded-lg border-2 transition-all hover:scale-105 ${
                       formData.icon === iconName
                         ? 'border-blue-500 bg-blue-50'
-                        : 'border-gray-200 hover:border-gray-300'
+                        : 'border-gray-200 dark:border-gray-600 hover:border-gray-300'
                     }`}
                     aria-label={iconName}
                   >
@@ -194,11 +194,11 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
             </div>
           </div>
 
-          <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100">
+          <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100 dark:border-gray-700">
             <button
               type="button"
               onClick={onClose}
-              className="px-6 py-3 text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 font-medium transition-colors"
+              className="px-6 py-3 text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 font-medium transition-colors"
             >
               Cancel
             </button>

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -41,13 +41,13 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
   const availableSubCategories = selectedCategory?.subs || [];
 
   const sidebarContent = (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col text-gray-700 dark:text-gray-200">
       {isMobile && (
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
           <h2 className="text-lg font-semibold text-gray-900">Filters</h2>
           <button
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
           >
             <X className="w-5 h-5" />
           </button>
@@ -57,7 +57,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
       <div className="flex-1 p-4 space-y-6">
         {/* Search */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
             Search Platforms
           </label>
           <div className="relative">
@@ -67,7 +67,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
               value={searchQuery}
               onChange={(e) => onSearchChange(e.target.value)}
               placeholder="Search by name or description..."
-              className="w-full pl-10 pr-4 py-3 border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              className="w-full pl-10 pr-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
             />
           </div>
         </div>
@@ -75,7 +75,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
         {/* Main Categories */}
         <div>
           <div className="flex items-center justify-between mb-3">
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">
               Main Categories
             </label>
             {(selectedMainCategory || selectedSubCategory || searchQuery) && (
@@ -93,7 +93,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
               className={`w-full text-left px-3 py-2 rounded-lg transition-colors ${
                 !selectedMainCategory
                   ? 'bg-blue-100 text-blue-800 border border-blue-200'
-                  : 'hover:bg-gray-50'
+                  : 'hover:bg-gray-50 dark:hover:bg-gray-700'
               }`}
             >
               All Categories
@@ -105,7 +105,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
                 className={`w-full text-left px-3 py-2 rounded-lg transition-colors border ${
                   selectedMainCategory === category.main
                     ? colorVariants[category.color]
-                    : 'hover:bg-gray-50 border-transparent'
+                    : 'hover:bg-gray-50 dark:hover:bg-gray-700 border-transparent'
                 }`}
               >
                 {category.main}
@@ -117,7 +117,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
         {/* Sub Categories */}
         {selectedMainCategory && availableSubCategories.length > 0 && (
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-3">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
               Sub Categories
             </label>
             <div className="space-y-2">
@@ -125,8 +125,8 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
                 onClick={() => onSubCategoryChange('')}
                 className={`w-full text-left px-3 py-2 rounded-lg transition-colors ${
                   !selectedSubCategory
-                    ? 'bg-gray-100 text-gray-800 border border-gray-200'
-                    : 'hover:bg-gray-50'
+                    ? 'bg-gray-100 text-gray-800 border border-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600'
+                    : 'hover:bg-gray-50 dark:hover:bg-gray-700'
                 }`}
               >
                 All Sub Categories
@@ -138,7 +138,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
                   className={`w-full text-left px-3 py-2 rounded-lg transition-colors text-sm border ${
                     selectedSubCategory === sub
                       ? (selectedCategory ? colorVariants[selectedCategory.color] : '')
-                      : 'hover:bg-gray-50 border-transparent'
+                      : 'hover:bg-gray-50 dark:hover:bg-gray-700 border-transparent'
                   }`}
                 >
                   {sub}
@@ -158,7 +158,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
           <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40" onClick={onClose} />
         )}
         <div
-          className={`fixed left-0 top-0 h-full w-80 bg-white border-r border-gray-200 shadow-xl z-50 transform transition-transform duration-300 ${
+          className={`fixed left-0 top-0 h-full w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-xl z-50 transform transition-transform duration-300 ${
             isOpen ? 'translate-x-0' : '-translate-x-full'
           }`}
         >
@@ -169,7 +169,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
   }
 
   return (
-    <div className="w-80 bg-white border-r border-gray-200 shadow-sm">
+    <div className="w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 shadow-sm">
       {sidebarContent}
     </div>
   );

--- a/src/components/PlatformCard.tsx
+++ b/src/components/PlatformCard.tsx
@@ -27,8 +27,8 @@ export const PlatformCard: React.FC<PlatformCardProps> = ({ platform }) => {
   const IconComponent = (Icons as any)[platform.icon] || Icons.Globe;
   
   return (
-    <div 
-      className="group bg-white rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 border border-gray-100 overflow-hidden"
+    <div
+      className="group bg-white dark:bg-gray-800 rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 border border-gray-100 dark:border-gray-700 overflow-hidden"
     >
       <div 
         className={`h-24 bg-gradient-to-br ${colorVariants[platform.color as keyof typeof colorVariants]} ${hoverVariants[platform.color as keyof typeof hoverVariants]} transition-all duration-300 flex items-center justify-center relative`}
@@ -41,19 +41,19 @@ export const PlatformCard: React.FC<PlatformCardProps> = ({ platform }) => {
       
       <div className="p-6">
         <div className="flex items-start justify-between mb-2">
-          <h3 className="font-semibold text-gray-900 text-lg group-hover:text-gray-700 transition-colors">
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-lg group-hover:text-gray-700 dark:group-hover:text-gray-300 transition-colors">
             {platform.name}
           </h3>
         </div>
-        
-        <p className="text-gray-600 text-sm mb-4 line-clamp-2">
+
+        <p className="text-gray-600 dark:text-gray-400 text-sm mb-4 line-clamp-2">
           {platform.description}
         </p>
-        
+
         <div className="flex items-center justify-between">
           <div className="flex flex-col">
-            <span className="text-xs font-medium text-gray-900">{platform.mainCategory}</span>
-            <span className="text-xs text-gray-500">{platform.subCategory}</span>
+            <span className="text-xs font-medium text-gray-900 dark:text-gray-100">{platform.mainCategory}</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">{platform.subCategory}</span>
           </div>
           
           <a

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- enable `darkMode` in Tailwind config
- add theme toggler with sun/moon button and persist preference
- style components with dark variants
- mention dark mode in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684db955f8cc832cb3845acf1ce1241a