### PR TITLE
Add dynamic category management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,15 +3,21 @@ import { Plus, Menu, LayoutDashboard, Sun, Moon } from 'lucide-react';
 import { PlatformCard } from './components/PlatformCard';
 import { AddPlatformModal } from './components/AddPlatformModal';
 import { FilterSidebar } from './components/FilterSidebar';
-import { Platform } from './types';
-import { defaultPlatforms, categories } from './data/platforms';
+import { AddCategoryModal } from './components/AddCategoryModal';
+import { Platform, Category } from './types';
+import { defaultPlatforms, categories as initialCategories } from './data/platforms';
 
 function App() {
   const [platforms, setPlatforms] = useState<Platform[]>(defaultPlatforms);
+  const [categories, setCategories] = useState<Category[]>(() => {
+    const stored = localStorage.getItem('categories');
+    return stored ? JSON.parse(stored) : initialCategories;
+  });
   const [selectedMainCategory, setSelectedMainCategory] = useState('');
   const [selectedSubCategory, setSelectedSubCategory] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isAddCategoryModalOpen, setIsAddCategoryModalOpen] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(false);
 
@@ -21,6 +27,10 @@ function App() {
       setIsDarkMode(true);
     }
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('categories', JSON.stringify(categories));
+  }, [categories]);
 
   useEffect(() => {
     if (isDarkMode) {
@@ -50,6 +60,10 @@ function App() {
       id: Date.now().toString()
     };
     setPlatforms(prev => [...prev, platform]);
+  };
+
+  const handleAddCategory = (category: Category) => {
+    setCategories(prev => [...prev, category]);
   };
 
   const handleClearFilters = () => {
@@ -139,6 +153,13 @@ function App() {
                   <Plus className="w-4 h-4" />
                   <span className="hidden sm:inline">Add Platform</span>
                 </button>
+                <button
+                  onClick={() => setIsAddCategoryModalOpen(true)}
+                  className="flex items-center space-x-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium shadow-sm hover:shadow-md"
+                >
+                  <Plus className="w-4 h-4" />
+                  <span className="hidden sm:inline">Add Category</span>
+                </button>
               </div>
             </div>
           </div>
@@ -216,6 +237,11 @@ function App() {
         onClose={() => setIsAddModalOpen(false)}
         onAdd={handleAddPlatform}
         categories={categories}
+      />
+      <AddCategoryModal
+        isOpen={isAddCategoryModalOpen}
+        onClose={() => setIsAddCategoryModalOpen(false)}
+        onAdd={handleAddCategory}
       />
     </div>
   );

--- a/src/components/AddCategoryModal.tsx
+++ b/src/components/AddCategoryModal.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { X, Plus } from 'lucide-react';
+import { Category, ColorVariant } from '../types';
+
+interface AddCategoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdd: (category: Category) => void;
+}
+
+const colorOptions: ColorVariant[] = ['orange', 'pink', 'blue', 'purple', 'green'];
+
+export const AddCategoryModal: React.FC<AddCategoryModalProps> = ({ isOpen, onClose, onAdd }) => {
+  const [formData, setFormData] = useState<{ main: string; subs: string; color: ColorVariant }>({
+    main: '',
+    subs: '',
+    color: 'blue'
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.main.trim()) return;
+
+    const subsArray = formData.subs
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+
+    onAdd({ main: formData.main.trim(), subs: subsArray, color: formData.color });
+    setFormData({ main: '', subs: '', color: 'blue' });
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white/80 dark:bg-gray-800/70 backdrop-blur-xl rounded-2xl shadow-2xl w-full max-w-lg">
+        <div className="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Add New Category</h2>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+            <span className="sr-only">Close</span>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+              Category Name *
+            </label>
+            <input
+              type="text"
+              value={formData.main}
+              onChange={e => setFormData(prev => ({ ...prev, main: e.target.value }))}
+              className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              placeholder="e.g., Productivity"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+              Sub Categories (comma separated)
+            </label>
+            <input
+              type="text"
+              value={formData.subs}
+              onChange={e => setFormData(prev => ({ ...prev, subs: e.target.value }))}
+              className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              placeholder="Design, Development"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">Color</label>
+            <select
+              value={formData.color}
+              onChange={e => setFormData(prev => ({ ...prev, color: e.target.value as ColorVariant }))}
+              className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+            >
+              {colorOptions.map(color => (
+                <option key={color} value={color}>
+                  {color.charAt(0).toUpperCase() + color.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-3 text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 font-medium transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors flex items-center space-x-2"
+            >
+              <Plus className="w-4 h-4" />
+              <span>Add Category</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add `AddCategoryModal` for creating categories dynamically
- manage categories in `App` state with persistence to `localStorage`
- allow adding categories from the header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dc0b0a9fc832ca39d1a44c246d484