### PR TITLE
Adjust sidebar layout and remove search field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ function App() {
   const [platforms, setPlatforms] = useState<Platform[]>(defaultPlatforms);
   const [selectedMainCategory, setSelectedMainCategory] = useState('');
   const [selectedSubCategory, setSelectedSubCategory] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -34,15 +33,14 @@ function App() {
 
   const filteredPlatforms = useMemo(() => {
     return platforms.filter(platform => {
-      const matchesMainCategory = !selectedMainCategory || platform.mainCategory === selectedMainCategory;
-      const matchesSubCategory = !selectedSubCategory || platform.subCategory === selectedSubCategory;
-      const matchesSearch = !searchQuery || 
-        platform.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        platform.description.toLowerCase().includes(searchQuery.toLowerCase());
-      
-      return matchesMainCategory && matchesSubCategory && matchesSearch;
+      const matchesMainCategory = !selectedMainCategory ||
+        platform.mainCategory === selectedMainCategory;
+      const matchesSubCategory = !selectedSubCategory ||
+        platform.subCategory === selectedSubCategory;
+
+      return matchesMainCategory && matchesSubCategory;
     });
-  }, [platforms, selectedMainCategory, selectedSubCategory, searchQuery]);
+  }, [platforms, selectedMainCategory, selectedSubCategory]);
 
   const handleAddPlatform = (newPlatform: Omit<Platform, 'id'>) => {
     const platform: Platform = {
@@ -55,7 +53,6 @@ function App() {
   const handleClearFilters = () => {
     setSelectedMainCategory('');
     setSelectedSubCategory('');
-    setSearchQuery('');
   };
 
   const handleMainCategoryChange = (category: string) => {
@@ -71,10 +68,8 @@ function App() {
           categories={categories}
           selectedMainCategory={selectedMainCategory}
           selectedSubCategory={selectedSubCategory}
-          searchQuery={searchQuery}
           onMainCategoryChange={handleMainCategoryChange}
           onSubCategoryChange={setSelectedSubCategory}
-          onSearchChange={setSearchQuery}
           onClearFilters={handleClearFilters}
         />
       </div>
@@ -84,10 +79,8 @@ function App() {
         categories={categories}
         selectedMainCategory={selectedMainCategory}
         selectedSubCategory={selectedSubCategory}
-        searchQuery={searchQuery}
         onMainCategoryChange={handleMainCategoryChange}
         onSubCategoryChange={setSelectedSubCategory}
-        onSearchChange={setSearchQuery}
         onClearFilters={handleClearFilters}
         isMobile
         isOpen={isMobileSidebarOpen}
@@ -112,7 +105,7 @@ function App() {
                     <LayoutDashboard className="w-6 h-6 text-blue-600" />
                   </div>
                   <div>
-                    <h1 className="text-2xl font-bold text-gray-900">Platform Dashboard</h1>
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Platform Dashboard</h1>
                     <p className="text-sm text-gray-600">
                       {filteredPlatforms.length} of {platforms.length} platforms
                     </p>
@@ -147,16 +140,11 @@ function App() {
         {/* Content */}
         <main className="flex-1 px-4 sm:px-6 lg:px-8 py-8">
           {/* Active Filters */}
-          {(selectedMainCategory || selectedSubCategory || searchQuery) && (
+          {(selectedMainCategory || selectedSubCategory) && (
             <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-2 text-sm">
                   <span className="text-blue-800 font-medium">Active filters:</span>
-                  {searchQuery && (
-                    <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded">
-                      Search: "{searchQuery}"
-                    </span>
-                  )}
                   {selectedMainCategory && (
                     <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded">
                       {selectedMainCategory}
@@ -193,8 +181,8 @@ function App() {
                 </div>
                 <h3 className="text-lg font-medium text-gray-900 mb-2">No platforms found</h3>
                 <p className="text-gray-600 mb-6">
-                  {searchQuery || selectedMainCategory || selectedSubCategory
-                    ? 'Try adjusting your filters or search query.'
+                  {selectedMainCategory || selectedSubCategory
+                    ? 'Try adjusting your filters.'
                     : 'Get started by adding your first platform.'}
                 </p>
                 <button

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { Search, Filter, X } from 'lucide-react';
+import { Filter, X } from 'lucide-react';
 import { Category, ColorVariant } from '../types';
 
 interface FilterSidebarProps {
   categories: Category[];
   selectedMainCategory: string;
   selectedSubCategory: string;
-  searchQuery: string;
   onMainCategoryChange: (category: string) => void;
   onSubCategoryChange: (subCategory: string) => void;
-  onSearchChange: (query: string) => void;
   onClearFilters: () => void;
   isMobile?: boolean;
   isOpen?: boolean;
@@ -28,10 +26,8 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
   categories,
   selectedMainCategory,
   selectedSubCategory,
-  searchQuery,
   onMainCategoryChange,
   onSubCategoryChange,
-  onSearchChange,
   onClearFilters,
   isMobile = false,
   isOpen = true,
@@ -55,30 +51,13 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
       )}
 
       <div className="flex-1 p-4 space-y-6">
-        {/* Search */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
-            Search Platforms
-          </label>
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="Search by name or description..."
-              className="w-full pl-10 pr-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
-            />
-          </div>
-        </div>
-
         {/* Main Categories */}
         <div>
           <div className="flex items-center justify-between mb-3">
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">
               Main Categories
             </label>
-            {(selectedMainCategory || selectedSubCategory || searchQuery) && (
+            {(selectedMainCategory || selectedSubCategory) && (
               <button
                 onClick={onClearFilters}
                 className="text-xs text-blue-600 hover:text-blue-700 font-medium"
@@ -169,7 +148,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
   }
 
   return (
-    <div className="w-80 bg-white/80 dark:bg-gray-800/60 backdrop-blur border-r border-gray-200 dark:border-gray-700 shadow-sm">
+    <div className="w-80 min-h-screen bg-white/80 dark:bg-gray-800/60 backdrop-blur border-r border-gray-200 dark:border-gray-700 shadow-sm">
       {sidebarContent}
     </div>
   );


### PR DESCRIPTION
## Summary
- make sidebar stretch to screen with `min-h-screen`
- remove search UI and related props from `FilterSidebar`
- drop search state and filter logic from `App`
- ensure "Platform Dashboard" text turns white in dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5a194d8832c9147618a8d261e81