### PR TITLE
Add optional subcategories and editing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,10 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { Plus, Menu, LayoutDashboard, Sun, Moon } from 'lucide-react';
 import { PlatformCard } from './components/PlatformCard';
 import { AddPlatformModal } from './components/AddPlatformModal';
+import { EditPlatformModal } from './components/EditPlatformModal';
 import { FilterSidebar } from './components/FilterSidebar';
 import { AddCategoryModal } from './components/AddCategoryModal';
+import { AddSubCategoryModal } from './components/AddSubCategoryModal';
 import { Platform, Category } from './types';
 import { defaultPlatforms, categories as initialCategories } from './data/platforms';
 
@@ -18,6 +20,9 @@ function App() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isAddCategoryModalOpen, setIsAddCategoryModalOpen] = useState(false);
+  const [isAddSubCategoryModalOpen, setIsAddSubCategoryModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [platformToEdit, setPlatformToEdit] = useState<Platform | null>(null);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(false);
 
@@ -64,6 +69,20 @@ function App() {
 
   const handleAddCategory = (category: Category) => {
     setCategories(prev => [...prev, category]);
+  };
+
+  const handleAddSubCategory = (main: string, sub: string) => {
+    setCategories(prev =>
+      prev.map(cat =>
+        cat.main === main && !cat.subs.includes(sub)
+          ? { ...cat, subs: [...cat.subs, sub] }
+          : cat
+      )
+    );
+  };
+
+  const handleUpdatePlatform = (updated: Platform) => {
+    setPlatforms(prev => prev.map(p => (p.id === updated.id ? updated : p)));
   };
 
   const handleClearFilters = () => {
@@ -160,6 +179,13 @@ function App() {
                   <Plus className="w-4 h-4" />
                   <span className="hidden sm:inline">Add Category</span>
                 </button>
+                <button
+                  onClick={() => setIsAddSubCategoryModalOpen(true)}
+                  className="flex items-center space-x-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors font-medium shadow-sm hover:shadow-md"
+                >
+                  <Plus className="w-4 h-4" />
+                  <span className="hidden sm:inline">Add Sub Category</span>
+                </button>
               </div>
             </div>
           </div>
@@ -203,7 +229,14 @@ function App() {
           {filteredPlatforms.length > 0 ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
               {filteredPlatforms.map(platform => (
-                <PlatformCard key={platform.id} platform={platform} />
+                <PlatformCard
+                  key={platform.id}
+                  platform={platform}
+                  onEdit={p => {
+                    setPlatformToEdit(p);
+                    setIsEditModalOpen(true);
+                  }}
+                />
               ))}
             </div>
           ) : (
@@ -238,10 +271,26 @@ function App() {
         onAdd={handleAddPlatform}
         categories={categories}
       />
+      <EditPlatformModal
+        isOpen={isEditModalOpen}
+        onClose={() => {
+          setIsEditModalOpen(false);
+          setPlatformToEdit(null);
+        }}
+        onSave={handleUpdatePlatform}
+        categories={categories}
+        platform={platformToEdit}
+      />
       <AddCategoryModal
         isOpen={isAddCategoryModalOpen}
         onClose={() => setIsAddCategoryModalOpen(false)}
         onAdd={handleAddCategory}
+      />
+      <AddSubCategoryModal
+        isOpen={isAddSubCategoryModalOpen}
+        onClose={() => setIsAddSubCategoryModalOpen(false)}
+        categories={categories}
+        onAdd={handleAddSubCategory}
       />
     </div>
   );

--- a/src/components/AddSubCategoryModal.tsx
+++ b/src/components/AddSubCategoryModal.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { X, Plus } from 'lucide-react';
+import { Category } from '../types';
+
+interface AddSubCategoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  categories: Category[];
+  onAdd: (mainCategory: string, subCategory: string) => void;
+}
+
+export const AddSubCategoryModal: React.FC<AddSubCategoryModalProps> = ({
+  isOpen,
+  onClose,
+  categories,
+  onAdd
+}) => {
+  const [formData, setFormData] = useState<{ main: string; sub: string }>({
+    main: '',
+    sub: ''
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.main || !formData.sub.trim()) return;
+
+    onAdd(formData.main, formData.sub.trim());
+    setFormData({ main: '', sub: '' });
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white/80 dark:bg-gray-800/70 backdrop-blur-xl rounded-2xl shadow-2xl w-full max-w-lg">
+        <div className="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Add Sub Category</h2>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+            <span className="sr-only">Close</span>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+              Category *
+            </label>
+            <select
+              value={formData.main}
+              onChange={e => setFormData(prev => ({ ...prev, main: e.target.value }))}
+              className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              required
+            >
+              <option value="">Select category</option>
+              {categories.map(cat => (
+                <option key={cat.main} value={cat.main}>
+                  {cat.main}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+              Sub Category Name *
+            </label>
+            <input
+              type="text"
+              value={formData.sub}
+              onChange={e => setFormData(prev => ({ ...prev, sub: e.target.value }))}
+              className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              placeholder="e.g., Collaboration"
+              required
+            />
+          </div>
+
+          <div className="flex justify-end space-x-4 pt-6 border-t border-gray-100 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-6 py-3 text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 font-medium transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors flex items-center space-x-2"
+            >
+              <Plus className="w-4 h-4" />
+              <span>Add Sub Category</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/components/EditPlatformModal.tsx
+++ b/src/components/EditPlatformModal.tsx
@@ -1,75 +1,81 @@
-import React, { useState } from 'react';
-import { X, Plus } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { X, Pencil } from 'lucide-react';
 import * as Icons from 'lucide-react';
 import { Platform, Category } from '../types';
 
-interface AddPlatformModalProps {
+interface EditPlatformModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAdd: (platform: Omit<Platform, 'id'>) => void;
+  onSave: (platform: Platform) => void;
   categories: Category[];
+  platform: Platform | null;
 }
 
 const availableIcons = [
-  'Globe', 'Code', 'FileText', 'BookOpen', 'Play', 'Music', 'Github', 'Figma',
-  'Camera', 'Palette', 'Monitor', 'Smartphone', 'Headphones', 'Calendar',
-  'MessageCircle', 'Mail', 'Users', 'Settings', 'Star', 'Heart'
+  'Globe',
+  'Code',
+  'FileText',
+  'BookOpen',
+  'Play',
+  'Music',
+  'Github',
+  'Figma',
+  'Camera',
+  'Palette',
+  'Monitor',
+  'Smartphone',
+  'Headphones',
+  'Calendar',
+  'MessageCircle',
+  'Mail',
+  'Users',
+  'Settings',
+  'Star',
+  'Heart'
 ];
 
-export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
+export const EditPlatformModal: React.FC<EditPlatformModalProps> = ({
   isOpen,
   onClose,
-  onAdd,
-  categories
+  onSave,
+  categories,
+  platform
 }) => {
-  const [formData, setFormData] = useState<Omit<Platform, 'id'>>({
-    name: '',
-    url: '',
-    description: '',
-    mainCategory: '',
-    subCategory: '',
-    icon: 'Globe',
-    color: 'blue'
-  });
-
+  const [formData, setFormData] = useState<Platform | null>(platform);
   const [availableSubCategories, setAvailableSubCategories] = useState<string[]>([]);
+
+  useEffect(() => {
+    setFormData(platform);
+    if (platform) {
+      const category = categories.find(cat => cat.main === platform.mainCategory);
+      setAvailableSubCategories(category?.subs || []);
+    }
+  }, [platform, categories]);
 
   const handleMainCategoryChange = (mainCategory: string) => {
     const category = categories.find(cat => cat.main === mainCategory);
     setAvailableSubCategories(category?.subs || []);
-    setFormData(prev => ({
-      ...prev,
-      mainCategory,
-      subCategory: '',
-      color: category?.color || 'blue'
-    }));
+    setFormData(prev =>
+      prev ? { ...prev, mainCategory, subCategory: '', color: category?.color || 'blue' } : prev
+    );
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!formData) return;
     if (formData.name && formData.url && formData.mainCategory) {
-      onAdd(formData);
-      setFormData({
-        name: '',
-        url: '',
-        description: '',
-        mainCategory: '',
-        subCategory: '',
-        icon: 'Globe',
-        color: 'blue'
-      });
-      setAvailableSubCategories([]);
+      onSave(formData);
       onClose();
     }
   };
 
-  if (!isOpen) return null;
+  if (!isOpen || !formData) return null;
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-white/80 dark:bg-gray-800/70 backdrop-blur-xl rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Add New Platform</h2>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Edit Platform</h2>
           <button
             onClick={onClose}
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
@@ -89,7 +95,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
               <input
                 type="text"
                 value={formData.name}
-                onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                onChange={e => setFormData(prev => (prev ? { ...prev, name: e.target.value } : prev))}
                 className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 placeholder="e.g., GitHub"
                 required
@@ -103,7 +109,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
               <input
                 type="url"
                 value={formData.url}
-                onChange={(e) => setFormData(prev => ({ ...prev, url: e.target.value }))}
+                onChange={e => setFormData(prev => (prev ? { ...prev, url: e.target.value } : prev))}
                 className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 placeholder="https://example.com"
                 required
@@ -117,7 +123,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
             </label>
             <textarea
               value={formData.description}
-              onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+              onChange={e => setFormData(prev => (prev ? { ...prev, description: e.target.value } : prev))}
               rows={3}
               className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all resize-none"
               placeholder="Brief description of the platform..."
@@ -131,7 +137,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
               </label>
               <select
                 value={formData.mainCategory}
-                onChange={(e) => handleMainCategoryChange(e.target.value)}
+                onChange={e => handleMainCategoryChange(e.target.value)}
                 className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 required
               >
@@ -145,12 +151,12 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
             </div>
 
             <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-2">
                 Sub Category
               </label>
               <select
                 value={formData.subCategory}
-                onChange={(e) => setFormData(prev => ({ ...prev, subCategory: e.target.value }))}
+                onChange={e => setFormData(prev => (prev ? { ...prev, subCategory: e.target.value } : prev))}
                 className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
                 disabled={!formData.mainCategory}
               >
@@ -175,9 +181,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
                   <button
                     key={iconName}
                     type="button"
-                    onClick={() =>
-                      setFormData(prev => ({ ...prev, icon: iconName }))
-                    }
+                    onClick={() => setFormData(prev => (prev ? { ...prev, icon: iconName } : prev))}
                     className={`p-3 rounded-lg border-2 transition-all hover:scale-105 ${
                       formData.icon === iconName
                         ? 'border-blue-500 bg-blue-50'
@@ -205,8 +209,8 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
               type="submit"
               className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium transition-colors flex items-center space-x-2"
             >
-              <Plus className="w-4 h-4" />
-              <span>Add Platform</span>
+              <Pencil className="w-4 h-4" />
+              <span>Update Platform</span>
             </button>
           </div>
         </form>

--- a/src/components/PlatformCard.tsx
+++ b/src/components/PlatformCard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Pencil } from 'lucide-react';
 import * as Icons from 'lucide-react';
 import { Platform, ColorVariant } from '../types';
 
 interface PlatformCardProps {
   platform: Platform;
+  onEdit: (platform: Platform) => void;
 }
 
 const colorVariants: Record<ColorVariant, string> = {
@@ -23,7 +24,7 @@ const hoverVariants: Record<ColorVariant, string> = {
   green: 'hover:from-green-600 hover:to-green-700'
 };
 
-export const PlatformCard: React.FC<PlatformCardProps> = ({ platform }) => {
+export const PlatformCard: React.FC<PlatformCardProps> = ({ platform, onEdit }) => {
   const IconComponent = (Icons as any)[platform.icon] || Icons.Globe;
   
   return (
@@ -34,7 +35,10 @@ export const PlatformCard: React.FC<PlatformCardProps> = ({ platform }) => {
         className={`h-24 bg-gradient-to-br ${colorVariants[platform.color as keyof typeof colorVariants]} ${hoverVariants[platform.color as keyof typeof hoverVariants]} transition-all duration-300 flex items-center justify-center relative`}
       >
         <IconComponent className="w-8 h-8 text-white" />
-        <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+        <div className="absolute top-3 right-3 flex space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+          <button onClick={() => onEdit(platform)} className="p-1" aria-label="Edit">
+            <Pencil className="w-4 h-4 text-white/80" />
+          </button>
           <ExternalLink className="w-4 h-4 text-white/80" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make sub-category optional when adding a platform
- allow editing platforms
- allow adding sub-categories to existing categories
- expose edit and sub-category UI in the dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dc7693f3c832c943ea23af4209166