### PR TITLE
Apply single color style

### DIFF
--- a/src/components/AddCategoryModal.tsx
+++ b/src/components/AddCategoryModal.tsx
@@ -35,7 +35,7 @@ export const AddCategoryModal: React.FC<AddCategoryModalProps> = ({ isOpen, onCl
       .map(s => s.trim())
       .filter(Boolean);
 
-    onAdd({ main: formData.main.trim(), subs: subsArray, color: 'blue' });
+    onAdd({ main: formData.main.trim(), subs: subsArray, color: 'primary' });
     setFormData({ main: '', subs: '' });
     onClose();
   };

--- a/src/components/AddPlatformModal.tsx
+++ b/src/components/AddPlatformModal.tsx
@@ -30,7 +30,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
     mainCategory: '',
     subCategory: '',
     icon: 'Globe',
-    color: 'blue'
+    color: 'primary'
   });
 
   const [availableSubCategories, setAvailableSubCategories] = useState<string[]>([]);
@@ -52,7 +52,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
       ...prev,
       mainCategory,
       subCategory: '',
-      color: category?.color || 'blue'
+      color: category?.color || 'primary'
     }));
   };
 
@@ -67,7 +67,7 @@ export const AddPlatformModal: React.FC<AddPlatformModalProps> = ({
         mainCategory: '',
         subCategory: '',
         icon: 'Globe',
-        color: 'blue'
+        color: 'primary'
       });
       setAvailableSubCategories([]);
       onClose();

--- a/src/components/EditPlatformModal.tsx
+++ b/src/components/EditPlatformModal.tsx
@@ -67,7 +67,7 @@ export const EditPlatformModal: React.FC<EditPlatformModalProps> = ({
     const category = categories.find(cat => cat.main === mainCategory);
     setAvailableSubCategories(category?.subs || []);
     setFormData(prev =>
-      prev ? { ...prev, mainCategory, subCategory: '', color: category?.color || 'blue' } : prev
+      prev ? { ...prev, mainCategory, subCategory: '', color: category?.color || 'primary' } : prev
     );
   };
 

--- a/src/components/PlatformCard.tsx
+++ b/src/components/PlatformCard.tsx
@@ -1,28 +1,15 @@
 import React from 'react';
 import { ExternalLink, Pencil } from 'lucide-react';
 import * as Icons from 'lucide-react';
-import { Platform, ColorVariant } from '../types';
+import { Platform } from '../types';
 
 interface PlatformCardProps {
   platform: Platform;
   onEdit: (platform: Platform) => void;
 }
 
-const colorVariants: Record<ColorVariant, string> = {
-  orange: 'from-orange-500 to-orange-600',
-  pink: 'from-pink-500 to-pink-600',
-  blue: 'from-blue-500 to-blue-600',
-  purple: 'from-purple-500 to-purple-600',
-  green: 'from-green-500 to-green-600'
-};
-
-const hoverVariants: Record<ColorVariant, string> = {
-  orange: 'hover:from-orange-600 hover:to-orange-700',
-  pink: 'hover:from-pink-600 hover:to-pink-700',
-  blue: 'hover:from-blue-600 hover:to-blue-700',
-  purple: 'hover:from-purple-600 hover:to-purple-700',
-  green: 'hover:from-green-600 hover:to-green-700'
-};
+const headerBg =
+  'bg-gradient-to-br from-primary/60 to-primary/80 hover:from-primary/70 hover:to-primary/90';
 
 export const PlatformCard: React.FC<PlatformCardProps> = ({ platform, onEdit }) => {
   const IconComponent = (Icons as any)[platform.icon] || Icons.Globe;
@@ -31,8 +18,8 @@ export const PlatformCard: React.FC<PlatformCardProps> = ({ platform, onEdit }) 
     <div
       className="group bg-white/80 dark:bg-gray-800/60 backdrop-blur rounded-xl shadow-sm hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 border border-white/60 dark:border-gray-700 overflow-hidden"
     >
-      <div 
-        className={`h-24 bg-gradient-to-br ${colorVariants[platform.color as keyof typeof colorVariants]} ${hoverVariants[platform.color as keyof typeof hoverVariants]} transition-all duration-300 flex items-center justify-center relative`}
+      <div
+        className={`h-24 ${headerBg} transition-all duration-300 flex items-center justify-center relative`}
       >
         <IconComponent className="w-8 h-8 text-white" />
         <div className="absolute top-3 right-3 flex space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
@@ -64,7 +51,7 @@ export const PlatformCard: React.FC<PlatformCardProps> = ({ platform, onEdit }) 
             href={platform.url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`px-4 py-2 bg-gradient-to-r ${colorVariants[platform.color as keyof typeof colorVariants]} text-white text-sm font-medium rounded-lg hover:shadow-lg transition-all duration-200 transform hover:scale-105 inline-flex items-center justify-center`}
+            className="px-4 py-2 bg-primary/80 hover:bg-primary text-white text-sm font-medium rounded-lg hover:shadow-lg transition-all duration-200 transform hover:scale-105 inline-flex items-center justify-center"
           >
             Visit
           </a>

--- a/src/data/platforms.ts
+++ b/src/data/platforms.ts
@@ -4,27 +4,27 @@ export const categories: Category[] = [
   {
     main: 'Productivity',
     subs: ['Task Management', 'Note Taking', 'Time Tracking', 'Communication', 'File Storage'],
-    color: 'orange'
+    color: 'primary'
   },
   {
     main: 'Entertainment',
     subs: ['Streaming', 'Gaming', 'Social Media', 'Music', 'Reading'],
-    color: 'pink'
+    color: 'primary'
   },
   {
     main: 'Learning',
     subs: ['Coding', 'Languages', 'Courses', 'Documentation', 'Tutorials'],
-    color: 'blue'
+    color: 'primary'
   },
   {
     main: 'Design',
     subs: ['Graphics', 'UI/UX', 'Photography', 'Icons', 'Inspiration'],
-    color: 'purple'
+    color: 'primary'
   },
   {
     main: 'Development',
     subs: ['Code Editors', 'Version Control', 'Hosting', 'APIs', 'Tools'],
-    color: 'green'
+    color: 'primary'
   }
 ];
 
@@ -37,7 +37,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Development',
     subCategory: 'Version Control',
     icon: 'Github',
-    color: 'green'
+    color: 'primary'
   },
   {
     id: '2',
@@ -47,7 +47,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Productivity',
     subCategory: 'Note Taking',
     icon: 'FileText',
-    color: 'orange'
+    color: 'primary'
   },
   {
     id: '3',
@@ -57,7 +57,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Design',
     subCategory: 'UI/UX',
     icon: 'Figma',
-    color: 'purple'
+    color: 'primary'
   },
   {
     id: '4',
@@ -67,7 +67,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Entertainment',
     subCategory: 'Streaming',
     icon: 'Play',
-    color: 'pink'
+    color: 'primary'
   },
   {
     id: '5',
@@ -77,7 +77,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Learning',
     subCategory: 'Languages',
     icon: 'BookOpen',
-    color: 'blue'
+    color: 'primary'
   },
   {
     id: '6',
@@ -87,7 +87,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Development',
     subCategory: 'Code Editors',
     icon: 'Code',
-    color: 'green'
+    color: 'primary'
   },
   {
     id: '7',
@@ -97,7 +97,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Productivity',
     subCategory: 'Task Management',
     icon: 'Kanban',
-    color: 'orange'
+    color: 'primary'
   },
   {
     id: '8',
@@ -107,7 +107,7 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Entertainment',
     subCategory: 'Music',
     icon: 'Music',
-    color: 'pink'
+    color: 'primary'
   },
   {
     id: '9',
@@ -117,6 +117,6 @@ export const defaultPlatforms: Platform[] = [
     mainCategory: 'Entertainment',
     subCategory: 'Social Media',
     icon: 'Linkedin',
-    color: 'pink'
+    color: 'primary'
   }
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type ColorVariant = 'orange' | 'pink' | 'blue' | 'purple' | 'green';
+export type ColorVariant = 'primary';
 
 export interface Platform {
   id: string;


### PR DESCRIPTION
## Summary
- set a single `primary` color for platform and category items
- simplify `PlatformCard` styling to always use the same color
- update forms to use the new color

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684de6a8f8d0832cbf2b38ecb1ba0836