### PR TITLE
Set filter text color to black in light mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -212,7 +212,7 @@ function AppContent() {
                 </div>
                   <button
                     onClick={handleClearFilters}
-                    className="text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300 font-medium text-sm"
+                    className="text-black dark:text-white hover:text-gray-700 dark:hover:text-gray-300 font-medium text-sm"
                   >
                     Clear all filters
                   </button>

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -173,7 +173,7 @@ function App() {
                 </div>
                   <button
                     onClick={handleClearFilters}
-                    className="text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300 font-medium text-sm"
+                    className="text-black dark:text-white hover:text-gray-700 dark:hover:text-gray-300 font-medium text-sm"
                   >
                     Clear all filters
                   </button>

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -26,7 +26,7 @@ export const FilterDropdown: React.FC<FilterDropdownProps> = ({
       <select
         value={selectedMainCategory}
         onChange={e => onMainCategoryChange(e.target.value)}
-        className="px-3 py-2 border border-gray-300 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100"
+        className="px-3 py-2 border border-gray-300 rounded-lg bg-white text-black dark:bg-gray-700 dark:text-gray-100"
       >
         <option value="">All Categories</option>
         {categories.map(category => (
@@ -40,7 +40,7 @@ export const FilterDropdown: React.FC<FilterDropdownProps> = ({
         <select
           value={selectedSubCategory}
           onChange={e => onSubCategoryChange(e.target.value)}
-          className="px-3 py-2 border border-gray-300 rounded-lg bg-white dark:bg-gray-700 dark:text-gray-100"
+          className="px-3 py-2 border border-gray-300 rounded-lg bg-white text-black dark:bg-gray-700 dark:text-gray-100"
         >
           <option value="">All Sub Categories</option>
           {availableSubCategories.map(sub => (
@@ -54,7 +54,7 @@ export const FilterDropdown: React.FC<FilterDropdownProps> = ({
       {(selectedMainCategory || selectedSubCategory) && (
         <button
           onClick={onClearFilters}
-          className="text-sm text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300"
+          className="text-sm text-black dark:text-white hover:text-gray-700 dark:hover:text-gray-300"
         >
           Clear
         </button>

--- a/src/components/FilterSidebar.tsx
+++ b/src/components/FilterSidebar.tsx
@@ -33,10 +33,10 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
   const availableSubCategories = selectedCategory?.subs || [];
 
   const sidebarContent = (
-    <div className="h-full flex flex-col text-gray-700 dark:text-gray-200">
+    <div className="h-full flex flex-col text-black dark:text-gray-200">
       {isMobile && (
         <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
-          <h2 className="text-lg font-semibold text-gray-900">Filters</h2>
+          <h2 className="text-lg font-semibold text-black dark:text-gray-200">Filters</h2>
           <button
             onClick={onClose}
             className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
@@ -50,13 +50,13 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
         {/* Main Categories */}
         <div>
           <div className="flex items-center justify-between mb-3">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">
+            <label className="block text-sm font-medium text-black dark:text-gray-200">
               Main Categories
             </label>
               {(selectedMainCategory || selectedSubCategory) && (
                 <button
                   onClick={onClearFilters}
-                  className="text-xs text-gray-900 dark:text-white hover:text-gray-700 dark:hover:text-gray-300 font-medium"
+                  className="text-xs text-black dark:text-white hover:text-gray-700 dark:hover:text-gray-300 font-medium"
                 >
                   Clear all
                 </button>
@@ -92,7 +92,7 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
         {/* Sub Categories */}
         {selectedMainCategory && availableSubCategories.length > 0 && (
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
+            <label className="block text-sm font-medium text-black dark:text-gray-200 mb-3">
               Sub Categories
             </label>
             <div className="space-y-2">


### PR DESCRIPTION
## Summary
- use `text-black` in `FilterSidebar`
- apply black text in `FilterDropdown` selects and button
- make clear button text black in `App` and `Dashboard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684df975c240832cbe2511c065464e48