### PR TITLE
Use DashApp logo

### DIFF
--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -2,6 +2,7 @@ import { useMsal } from '@azure/msal-react';
 import { loginRequest } from './authConfig';
 import { useState } from 'react';
 import { LogIn, Loader2 } from 'lucide-react';
+import DashAppLogo from './assets/DashApp.png';
 
 export default function LoginPage() {
   const { instance } = useMsal();
@@ -19,6 +20,11 @@ export default function LoginPage() {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-[var(--color-secondary)] via-[var(--color-accent)] to-[var(--color-primary)] dark:from-gray-800 dark:via-gray-900 dark:to-black p-4">
       <div className="bg-white/90 dark:bg-gray-800/80 backdrop-blur rounded-2xl shadow-xl p-8 w-full max-w-md space-y-6 text-center">
+        <img
+          src={DashAppLogo}
+          alt="Dashboard App logo"
+          className="mx-auto w-24 h-auto"
+        />
         <div>
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Platform Dashboard</h1>
           <p className="text-gray-600 dark:text-gray-300">Sign in to continue</p>

--- a/src/components/SideBanner.tsx
+++ b/src/components/SideBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DashAppLogo from '../assets/DashApp.png';
 
 interface SideBannerProps {
   onAddPlatform: () => void;
@@ -13,6 +14,11 @@ export const SideBanner: React.FC<SideBannerProps> = ({
 }) => {
   return (
     <div className="w-64 min-h-screen bg-white/80 dark:bg-gray-800/70 backdrop-blur border-r border-gray-200 dark:border-gray-700 p-4 space-y-4">
+      <img
+        src={DashAppLogo}
+        alt="Dashboard App logo"
+        className="w-24 h-auto mx-auto mb-2"
+      />
       <button
         onClick={onAddPlatform}
         className="w-full px-4 py-2 bg-primary/40 backdrop-blur-md text-gray-900 dark:text-white rounded-lg hover:bg-primary/50 transition-colors font-medium shadow-sm hover:shadow-md"


### PR DESCRIPTION
## Summary
- display DashApp logo on SSO login page
- show DashApp logo at the top of the sidebar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e0220be5c832c8385201649fad9b0