### PR TITLE
Remove dashboard title from header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { msalConfig } from './authConfig';
 import Dashboard from './Dashboard';
 import LoginPage from './LoginPage';
 import React, { useState, useMemo, useEffect } from 'react';
-import { Plus, LayoutDashboard, Sun, Moon } from 'lucide-react';
+import { Plus, Sun, Moon } from 'lucide-react';
 import { PlatformCard } from './components/PlatformCard';
 import { AddPlatformModal } from './components/AddPlatformModal';
 import { AddCategoryModal } from './components/AddCategoryModal';
@@ -143,17 +143,9 @@ function AppContent() {
           <div className="px-4 sm:px-6 lg:px-8 py-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-4">
-                <div className="flex items-center space-x-3">
-                  <div className="p-2 bg-primary/20 rounded-lg">
-                    <LayoutDashboard className="w-6 h-6 text-primary" />
-                  </div>
-                  <div>
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Platform Dashboard</h1>
-                    <p className="text-sm text-gray-600">
-                      {filteredPlatforms.length} of {platforms.length} platforms
-                    </p>
-                  </div>
-                </div>
+                <p className="text-sm text-gray-600">
+                  {filteredPlatforms.length} of {platforms.length} platforms
+                </p>
               </div>
               <div className="flex items-center space-x-4">
                 <SearchInput

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -96,17 +96,9 @@ function App() {
           <div className="px-4 sm:px-6 lg:px-8 py-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-4">
-                <div className="flex items-center space-x-3">
-                  <div className="p-2 bg-primary/20 rounded-lg">
-                    <LayoutDashboard className="w-6 h-6 text-primary" />
-                  </div>
-                  <div>
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Platform Dashboard</h1>
-                    <p className="text-sm text-gray-600">
-                      {filteredPlatforms.length} of {platforms.length} platforms
-                    </p>
-                  </div>
-                </div>
+                <p className="text-sm text-gray-600">
+                  {filteredPlatforms.length} of {platforms.length} platforms
+                </p>
               </div>
 
               <div className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
- simplify header by removing Platform Dashboard title and icon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e02d1a484832c9377845340f8356c