### PR TITLE
Add .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and add your OpenAI API key
+VITE_OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ Make sure to update `src/authConfig.ts` with your **Azure application client ID*
 
 ## AI Assistant
 
-To use the built-in chat assistant for platform suggestions, create a `.env` file with your OpenAI API key:
+To enable the chat assistant for platform suggestions:
+
+1. Copy `.env.example` to `.env` in the project root.
+2. Add your OpenAI API key to the `VITE_OPENAI_API_KEY` variable.
 
 ```bash
+# .env
 VITE_OPENAI_API_KEY=your-key-here
 ```


### PR DESCRIPTION
## Summary
- provide `.env.example` for AI assistant setup
- document copying it to `.env` and adding the OpenAI key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8e2a4d94832ca986046e59c45f61